### PR TITLE
fix: 헤더구현 - header를 상단에 고정

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,3 +11,24 @@ body {
     "Noto Sans KR",
     sans-serif;
 }
+
+ul,
+ol {
+  list-style: none;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+button {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+}
+
+.outlet-content {
+  padding-top: 88px;
+}

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,5 +1,8 @@
 .header-container {
-  width: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
   height: 88px;
   display: flex;
   justify-content: center;
@@ -12,7 +15,6 @@
   justify-content: space-between;
   align-items: center;
   padding: 0 16px;
-  margin: 0;
   gap: 40px;
 }
 

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -5,7 +5,7 @@ const Layout = () => {
   return (
     <>
       <Header />
-      <main>
+      <main className="outlet-content">
         <Outlet />
       </main>
     </>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App.jsx";
+import "./App.css";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>


### PR DESCRIPTION
## ✍️ 연관된 이슈
#7 
 
## ✅ Todos
- [x] 화면 상단에 헤더 고정
- [x] 페이지별 링크 구성

## 🧾내용
- 화면 상단에 헤더가 고정되도록 내용 추가